### PR TITLE
chore: export `SuperdaoRef`

### DIFF
--- a/contracts/superdao/lib.rs
+++ b/contracts/superdao/lib.rs
@@ -8,6 +8,8 @@
 // - limit registering to contract addresses only <- if gov token, maybe not
 // - emit events
 
+pub use superdao::SuperdaoRef;
+
 #[ink::contract]
 mod superdao {
     use ink::codegen::Env;

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -13,8 +13,6 @@ path = "lib.rs"
 
 [features]
 default = ["std"]
-std = [
-    "ink/std",
-]
+std = ["ink/std"]
 ink-as-dependency = []
 e2e-tests = []


### PR DESCRIPTION
We need SuperdaoRef for cross contract calling. 